### PR TITLE
Doubled the SAS URL expiry time

### DIFF
--- a/azure-storage-server/src/main/kotlin/jetbrains/buildServer/serverSide/artifacts/azure/web/AzureArtifactDownloadProcessor.kt
+++ b/azure-storage-server/src/main/kotlin/jetbrains/buildServer/serverSide/artifacts/azure/web/AzureArtifactDownloadProcessor.kt
@@ -50,7 +50,7 @@ class AzureArtifactDownloadProcessor : ArtifactDownloadProcessor {
         val path = AzureUtils.getArtifactPath(artifactInfo.commonProperties, artifactData.path)
         val lifeTime = urlLifeTime
 
-        val temporaryUrl = getTemporaryUrl(path, params, lifeTime)
+        val temporaryUrl = getTemporaryUrl(path, params, lifeTime * 2)
         response.setHeader(HttpHeaders.CACHE_CONTROL, "max-age=" + lifeTime)
         response.sendRedirect(temporaryUrl)
 


### PR DESCRIPTION
Fixes https://github.com/JetBrains/teamcity-azure-storage/issues/13

I left the cache control value on the next line the same since this could create a similar issue. That doubling gives it just a little bit of a buffer.