### PR TITLE
Used the `httpCacheMaxAge` for the internal cache

### DIFF
--- a/azure-storage-server/src/main/kotlin/jetbrains/buildServer/serverSide/artifacts/azure/web/AzureArtifactDownloadProcessor.kt
+++ b/azure-storage-server/src/main/kotlin/jetbrains/buildServer/serverSide/artifacts/azure/web/AzureArtifactDownloadProcessor.kt
@@ -36,7 +36,7 @@ import javax.servlet.http.HttpServletResponse
 
 class AzureArtifactDownloadProcessor : ArtifactDownloadProcessor {
     private val myLinksCache = CacheBuilder.newBuilder()
-            .expireAfterWrite(urlLifeTime.toLong(), TimeUnit.SECONDS)
+            .expireAfterWrite(httpCacheMaxAge.toLong(), TimeUnit.SECONDS)
             .maximumSize(100)
             .build<String, String>()
 


### PR DESCRIPTION
Fixes https://github.com/JetBrains/teamcity-azure-storage/issues/13

As described in the Issue, the internal cache hangs onto the URL for the exact amount of time it is valid for. With network overhead, this means it is invalid by the time it reaches the client.